### PR TITLE
Update redux-actions Reducer definition

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -57,7 +57,7 @@ declare module "redux-actions" {
   ): Object;
   declare function createActions(...identityActions: string[]): Object;
 
-  declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
 
   declare type ReducerMap<S, A> =
     | { next: Reducer<S, A> }


### PR DESCRIPTION
This is needed to match redux definitions changed in `v2.4.0`.
State can be `S` or `void`.